### PR TITLE
Logo senza sfondo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -183,9 +183,6 @@ img {
   border-radius: 50%;
   margin-left: -50%;
   display: inline-block;
-  box-shadow: 0 0 8px rgba(0, 0, 0, .8);
-  -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, .8);
-  -moz-box-shadow: 0 0 8px rgba(0, 0, 0, .8);
 }
 .navbar-custom .avatar-container  .avatar-img {
   width: 100%;
@@ -208,9 +205,6 @@ img {
 
   .navbar-custom .avatar-container  .avatar-img-border {
     width: 100%;
-    box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
-    -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
-    -moz-box-shadow: 1px 1px 2px rgba(0, 0, 0, .8);
   }
 
   .navbar-custom .avatar-container  .avatar-img {

--- a/css/main.css
+++ b/css/main.css
@@ -491,7 +491,7 @@ footer .theme-by {
     padding: 150px 0;
   }
   .intro-header .page-heading h1 {
-    font-size: 60px;
+    font-size: 50px;
   }
   .intro-header .post-heading h1 {
     font-size: 40px;

--- a/notizie.md
+++ b/notizie.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: NOTIZIE
+title: Notizie
 permalink: /notizie/
 ---
 


### PR DESCRIPTION
Rimuovi lo sfondo circolare bianco e l'ombreggiatura al logo. Secondo me risulta molto più pulito in questo modo
Prima:
![image](https://user-images.githubusercontent.com/14352721/77025128-9be67400-6990-11ea-8e13-eb240c992df8.png)

Dopo:
![image](https://user-images.githubusercontent.com/14352721/77025149-aacd2680-6990-11ea-9576-0fafa0658622.png)


