### PR TITLE
mappa

### DIFF
--- a/_layouts/issuelist.html
+++ b/_layouts/issuelist.html
@@ -49,7 +49,7 @@ layout: page
 
 <div class="row">
 
-<div class="row"><div class="col-md-12 col-sm-12 col-xs-12"> <div id="map" style="height: 600px;"></div> </div> </div>
+<div class="col-md-12 col-sm-12 col-xs-12"> <div id="map" style="height: 600px;"></div> </div>
 
 {% assign allcatfilteredissues = '' | split: '' %}
 {% for categoriatuple in categorieissue %}


### PR DESCRIPTION
corretto doppio contenitore (row) della mappa ora su mobile la pagina non dovrebbe più sbordare di lato