### PR TITLE
Fix overlap issue list

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -596,15 +596,6 @@ td.gutter {
 	margin-bottom: 30px;
 }
 
-/* --- Fix anchor hidden by navbar --- */
-*[id]:before {
-	display: block;
-	content: " ";
-	margin-top: -75px;
-	height: 75px;
-	visibility: hidden;
-}
-
 /* --- Fix https://github.com/emergenzeHack/terremotocentro/issues/58 --- */
 .panel {
 	overflow: hidden;


### PR DESCRIPTION
Eliminata la sovrapposizione degli h2 e dei button in [issuelist](https://github.com/emergenzeHack/covid19italia/blob/master/_layouts/issuelist_new.html).
Correlato a https://github.com/emergenzeHack/covid19italia/issues/364