### PR TITLE
Cambiato colore pulsanti

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -17,7 +17,7 @@ justLatestIssues: true
 <div class="row mx-auto">
 {% for category in issuecategories %}
   <div class="col-xs-12 col-sm-6 mb-15">
-	  <a href="/{{category[0] | slugify}}" class="btn btn-success btn-block">{{category[0]}}</a>
+	  <a href="/{{category[0] | slugify}}" class="btn btn-primary btn-block">{{category[0]}}</a>
 	</div>
 {% endfor %}
 </div>

--- a/regioni.md
+++ b/regioni.md
@@ -10,7 +10,7 @@ permalink: /issues/regione/
 <div class="row">
 {%- for regione in site.data.geo.regioni -%}
 <div class="col-md-6 col-sm-12 col-xs-12 mb-15">
-	  <a href="/issues/regione/{{regione.nome_regione | replace: "'", "" | slugify}}/" class="btn btn-success btn-block" >{{regione.nome_regione}}</a>
+	  <a href="/issues/regione/{{regione.nome_regione | replace: "'", "" | slugify}}/" class="btn btn-primary btn-block" >{{regione.nome_regione}}</a>
 </div>
 {%- endfor -%}
 </div>


### PR DESCRIPTION
Close https://github.com/emergenzeHack/covid19italia/issues/331.

Con questa pull si cambia semplicemente il tipo di pulsante di Bootstrap passando dalla classe `success` a quella `primary`, è lo stessa cosa che @mfortini ha fatto nella nuova issuelist come si può vedere scorrendo [qui](https://covid19italia.netlify.com/issues/).
Tuttavia il blu di Bootstrap **non** è quello della navbar. Usare quello sarebbe un po' più complicato perché andrebbero create classi apposta.
In realtà secondo me potrebbe avere un senso anche lasciare il verde o virare su qualcosa di più neutro.
Intanto propongo questo, ditemi voi.