### PR TITLE
Update notizia.html

### DIFF
--- a/_segnalazioni/notizia.html
+++ b/_segnalazioni/notizia.html
@@ -1,12 +1,12 @@
 ---
-lang: gr
+lang: it
 layout: page
-title: Καλές Ειδήσεις
-permalink: /anebase-pliroforia/good-news/
+title: Segnala - Notizia
+permalink: /segnala/notizia/
 ---
 
-<object class="iframe-embed iframe-embed--v200" data="https://ee.humanitarianresponse.info/x/#vz5SmHBw">
+<object class="iframe-embed iframe-embed--v200" data="https://ee.humanitarianresponse.info/i/::Vde7ElAa">
     <div class="offset-md-3 col-md-6">
-         <a class="btn btn-success btn-lg btn-block btn-form" href="https://ee.humanitarianresponse.info/x/#vz5SmHBw" target="_blank">Apri form</a>
+         <a class="btn btn-success btn-lg btn-block btn-form" href="https://ee.humanitarianresponse.info/i/::Vde7ElAa" target="_blank">Apri form</a>
     </div>
 </object>


### PR DESCRIPTION
Want to use bufala.html instead of notizia.html for our good news posts as the default label for bufala is ‘useful news’.