### PR TITLE
Update bufala.html

### DIFF
--- a/_segnalazioni/bufala.html
+++ b/_segnalazioni/bufala.html
@@ -1,8 +1,8 @@
 ---
 lang: gr
 layout: page
-title: Έκθεση - Δωρεά αγαθών ή υπηρεσιών
-permalink: /anebase-pliroforia/Δωρεά-αγαθών-υπηρεσιών/
+title: Καλές Ειδήσεις
+permalink: /anebase-pliroforia/good-news/
 ---
 
 <object class="iframe-embed iframe-embed--v200" data="https://ee.humanitarianresponse.info/x/#vz5SmHBw">


### PR DESCRIPTION
Want to use bufala.html instead of notizia.html for our good news posts as the default label for bufala is ‘useful news’.